### PR TITLE
#2 fixed, Node.js is v20.9.0, LTS

### DIFF
--- a/.rtx.toml
+++ b/.rtx.toml
@@ -1,3 +1,2 @@
 [tools]
-node = "18"
-nodejs = "16"
+node = "20.9.0"


### PR DESCRIPTION
I can't decide which is correct, `node` or `nodejs` on RTX.  
I chose `node`.